### PR TITLE
Forward express body to socket.io data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,7 @@ express.application.io = function(options) {
     req.isSocket = false;
     req.io = {};
     req.io.route = function(route) {
+      req.data = req.body
       return this.io.route(route, req, res);
     }.bind(this);
     req.param = function param(name, defaultValue) {


### PR DESCRIPTION
When forwarding routes, any data passed to an express route does not get inserted in the same place as the io.routes. This provides interoperability with a ton of express midleware that manipulates `body`
